### PR TITLE
Update setup, install, citation + streamline badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,53 @@
+[![Latest PyPI release](https://img.shields.io/pypi/v/ptitprince.svg)](https://pypi.org/project/ptitprince/)
+[![Downloads](https://pepy.tech/badge/ptitprince)](https://pepy.tech/project/ptitprince)
+[![Latest conda-forge release](https://img.shields.io/conda/vn/conda-forge/ptitprince.svg)](https://anaconda.org/conda-forge/ptitprince/)
+[![Binder](https://img.shields.io/badge/binder%20tutorial-python-fb62f6.svg)](https://mybinder.org/v2/gh/RainCloudPlots/RainCloudPlots/master?filepath=tutorial_python%2Fraincloud_tutorial_python.ipynb)
+
 # PtitPrince
 
-A python implementation of the Raincloud plot!
-[https://github.com/RainCloudPlots/RainCloudPlots](https://github.com/RainCloudPlots/RainCloudPlots)
+A Python implementation of the "Raincloud plot"!
+See: [https://github.com/RainCloudPlots/RainCloudPlots](https://github.com/RainCloudPlots/RainCloudPlots)
 
 ## Installation
-You can install it via
+
+You can install it via `pip`:
+
 ```
 pip install ptitprince
 ```
 
-or via conda
+or via `conda`:
+
 ```
-conda install -c pog87 ptitprince
+conda install -c conda-forge ptitprince
 ```
 
-or cloning this repo in your working directory and run the usual
+or by cloning this repository and running the following from the root of it:
 
 ```
 python setup.py install
 ```
 
------
 ## Academic use
 
 To **cite Raincloud plots** please use the following information:
 
-> Allen M, Poggiali D, Whitaker K et al. Raincloud plots: a multi-platform tool for robust data visualization [version 1; peer review: 2 approved]. Wellcome Open Res 2019, 4:63. DOI: [10.12688/wellcomeopenres.15191.1](https://doi.org/10.12688/wellcomeopenres.15191.1)
-
-
+> Allen M, Poggiali D, Whitaker K et al. Raincloud plots: a multi-platform tool for robust data visualization [version 2; peer review: 2 approved]. Wellcome Open Res 2021, 4:63 (https://doi.org/10.12688/wellcomeopenres.15191.2) 
 
 ![output](output_4_0.png)
 
-
 ## History of this project
-
  
-This is a python version of the Raincloud plot (or PetitPrince plot, depending on the orientation) from R (under ggplot2) to Python.  The Raincloud plot is a variant of the violin plot written in R ggplot2 by [Micah Allen](https://micahallen.org/2018/03/15/introducing-raincloud-plots/).
+This is a Python version of the "Raincloud plot" (or "PetitPrince plot", depending on the orientation) from R (under ggplot2) to Python.
+The Raincloud plot is a variant of the violin plot written in R ggplot2 by [Micah Allen](https://micahallen.org/2018/03/15/introducing-raincloud-plots/).
 
-I found a tweet asking for a .py version of the RainCloud plot, and I agreed to give it a try. Alas, the py version for ggplot2 does not allow to create new styles in a confortable way. So I decided to write this package using the [seaborn](https://seaborn.pydata.org/) library as a requisite.
+I found a tweet asking for a Python version of the Raincloud plot, and I agreed to give it a try.
+Alas, the Python version for ggplot2 ([plotnine](https://github.com/has2k1/plotnine)) does not allow to create new styles in a confortable way.
+So I decided to write this package using the [seaborn](https://seaborn.pydata.org/) library as a foundation.
 
----
+Then I replicated the plots from the original post by [Micah Allen](https://micahallen.org/2018/03/15/introducing-raincloud-plots/), in Jupyter Notebooks and transformed that code into a Python package.
 
-Then I replicated the plots from the original post by [Micah Allen](https://micahallen.org/2018/03/15/introducing-raincloud-plots/), using Jupyter.
+Since then, the package has received some publicity, and is for example listed in ["awesome-python-data-science"](https://github.com/thomasjpfan/awesome-python-data-science).
 
 ### Changelog
 
@@ -58,9 +64,3 @@ Then I replicated the plots from the original post by [Micah Allen](https://mica
  * ~~add a "move" option in seabon to control the positioning of each plot, as in ggplot2.~~ (either, added in ptitprince)
  * ~~get RainCloud published~~ (done!)
  * add logarithic density estimate (LDE) to the options for the cloud
-
-------
-[![Binder](https://img.shields.io/badge/binder%20tutorial-python-fb62f6.svg)](https://mybinder.org/v2/gh/RainCloudPlots/RainCloudPlots/master?filepath=tutorial_python%2Fraincloud_tutorial_python.ipynb)
-[![Downloads](https://pepy.tech/badge/ptitprince)](https://pepy.tech/project/ptitprince)
-
-[List](https://github.com/thomasjpfan/awesome-python-data-science) that metions this package.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is a Python version of the "Raincloud plot" (or "PetitPrince plot", dependi
 The Raincloud plot is a variant of the violin plot written in R ggplot2 by [Micah Allen](https://micahallen.org/2018/03/15/introducing-raincloud-plots/).
 
 I found a tweet asking for a Python version of the Raincloud plot, and I agreed to give it a try.
-Alas, the Python version for ggplot2 ([plotnine](https://github.com/has2k1/plotnine)) does not allow to create new styles in a confortable way.
+Alas, the Python version for ggplot2 ([plotnine](https://github.com/has2k1/plotnine)) does not allow to create new styles in a comfortable way.
 So I decided to write this package using the [seaborn](https://seaborn.pydata.org/) library as a foundation.
 
 Then I replicated the plots from the original post by [Micah Allen](https://micahallen.org/2018/03/15/introducing-raincloud-plots/), in Jupyter Notebooks and transformed that code into a Python package.

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,40 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='ptitprince',
       version='0.2.5',
       description='A Python implementation of Rainclouds, originally on R, ggplot2. Written on top of seaborn.',
-      url='http://github.com/pog87/PtitPrince',
+      long_description=open('README.md').read(),
+      long_description_content_type='text/markdown',      
+      url='https://github.com/pog87/PtitPrince',
       author='Davide Poggiali',
       author_email='davide.poggiali@unipd.it',
       license='MIT',
-      packages=['ptitprince'],
+      packages=find_packages(),
+      platform='any',
+      keywords=[
+          'data visualization',
+          'raincloud plots',
+      ],
+      classifiers=[
+          'Intended Audience :: Science/Research',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved',
+          'Programming Language :: Python',
+          'Topic :: Software Development',
+          'Topic :: Scientific/Engineering',
+          'Operating System :: Microsoft :: Windows',
+          'Operating System :: POSIX',
+          'Operating System :: Unix',
+          'Operating System :: MacOS',
+      ],      
       install_requires=[
-          'seaborn>=0.11', 'matplotlib', 'numpy>=1.13', 'scipy',
-          'PyHamcrest>=1.9.0', 'cython'
+          'seaborn>=0.11',
+          'matplotlib',
+          'numpy>=1.13',
+          'scipy',
+          'PyHamcrest>=1.9.0',
+          'cython'
       ],
       zip_safe=False)
+
+

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,3 @@ setup(name='ptitprince',
           'cython'
       ],
       zip_safe=False)
-
-


### PR DESCRIPTION
Follow up PR to #18 


potential todos:
- [ ] update dependencies to those that are minimally required (e.g., I don't think `cython` is really needed, is it?)
- [ ] remove the duplicate license file from `/ptitprince/LICENSE`, because there is already the LICENSE in the root
- [ ] remove `output_4_0_png` and `output_5_0_png`, and replace the reference to `output_4_0_png` in the README with one of the images in `figs/tutorial_python`
- [ ] potentially remove `RainCloud_Plot.ipynb`? It seems like the tutorial `ipynb` is placed in `tutorial_python/
raincloud_tutorial_python.ipynb `