### PR TITLE
Add support for numpy > 1.23

### DIFF
--- a/ptitprince/PtitPrince.py
+++ b/ptitprince/PtitPrince.py
@@ -373,8 +373,8 @@ class _Half_ViolinPlotter(_CategoricalPlotter):
 
                 # Handle special case of a single observation
                 elif support.size == 1:
-                    val = np.asscalar(support)
-                    d = np.asscalar(density)
+                    val = np.ndarray.item(support)
+                    d = np.ndarray.item(density)
                     self.draw_single_observation(ax, i, val, d)
                     continue
 
@@ -429,8 +429,8 @@ class _Half_ViolinPlotter(_CategoricalPlotter):
 
                     # Handle the special case where we have one observation
                     elif support.size == 1:
-                        val = np.asscalar(support)
-                        d = np.asscalar(density)
+                        val = np.ndarray.item(support)
+                        d = np.ndarray.item(density)
                         if self.split:
                             d = d / 2
                         at_group = i + offsets[j]


### PR DESCRIPTION
This PR adds support newer numpy versions (> 1.23) since numpy dropped support for `numpy.asscalar`. This is also a backwards compatible change with older Numpy versions.